### PR TITLE
Removed unnecessary prompt at encryption

### DIFF
--- a/history-sync.plugin.zsh
+++ b/history-sync.plugin.zsh
@@ -83,7 +83,7 @@ function history_sync_push() {
         recipients+=$name
     fi
 
-    ENCRYPT_CMD="gpg -v "
+    ENCRYPT_CMD="gpg --yes -v "
     for r in $recipients; do
         ENCRYPT_CMD+="-r \"$r\" "
     done


### PR DESCRIPTION
Removed unnecessary prompt at encryption - user need to answer yes every time, otherwise tool just will not work - what's the point then?